### PR TITLE
fix CommandText missing issue

### DIFF
--- a/src/SQLAsyncOutputCacheProvider/SqlOutputCacheRepository.cs
+++ b/src/SQLAsyncOutputCacheProvider/SqlOutputCacheRepository.cs
@@ -312,6 +312,7 @@ namespace Microsoft.AspNet.OutputCache.SQLAsyncOutputCacheProvider {
 
         private void CreateTableIfNotExists(string createTableSql) {
             using (var cmd = new SqlCommand()) {
+                cmd.CommandText = createTableSql;
                 using (var connection = new SqlConnection(ConnectionString)) {
                     SqlExecuteNonQueryAsync(connection, cmd).GetAwaiter().GetResult();
                 }


### PR DESCRIPTION
CommandText is not set in CreateTableIfNotExists method.