### PR TITLE
Fix sbom settings; Fix 'CompilerGeneratedFilesOutputPath' warning

### DIFF
--- a/azure-pipeline/azure-pipeline-build.yml
+++ b/azure-pipeline/azure-pipeline-build.yml
@@ -30,7 +30,6 @@ stages:
         artifactName: Nuget packages
         targetPath: $(Build.SourcesDirectory)\bin\Release\Packages
         sbomEnabled: true
-        sbomBuildDropPath: $(Build.SourcesDirectory)\bin\Release\Packages
         sbomBuildComponentPath: $(Build.SourcesDirectory)\bin\Release\Packages
         sbomPackageName: Microsoft.AspNet.OutputCache
         sbomValidate: true

--- a/test/Microsoft.AspNet.OutputCache.CosmosDBTableAsyncOutputCacheProvider.Test/Microsoft.AspNet.OutputCache.CosmosDBTableAsyncOutputCacheProvider.Test.csproj
+++ b/test/Microsoft.AspNet.OutputCache.CosmosDBTableAsyncOutputCacheProvider.Test/Microsoft.AspNet.OutputCache.CosmosDBTableAsyncOutputCacheProvider.Test.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.OutputCache.sln))\tools\TestProject.settings.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.OutputCache.sln))\tools\TestProject.settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/test/Microsoft.AspNet.OutputCache.OutputCacheModuleAsync.Test/Microsoft.AspNet.OutputCache.OutputCacheModuleAsync.Test.csproj
+++ b/test/Microsoft.AspNet.OutputCache.OutputCacheModuleAsync.Test/Microsoft.AspNet.OutputCache.OutputCacheModuleAsync.Test.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.OutputCache.sln))\tools\TestProject.settings.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.OutputCache.sln))\tools\TestProject.settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/test/Microsoft.AspNet.OutputCache.SQLAsyncOutputCacheProvider.Test/Microsoft.AspNet.OutputCache.SQLAsyncOutputCacheProvider.Test.csproj
+++ b/test/Microsoft.AspNet.OutputCache.SQLAsyncOutputCacheProvider.Test/Microsoft.AspNet.OutputCache.SQLAsyncOutputCacheProvider.Test.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props')" />
   <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.OutputCache.sln))\tools\TestProject.settings.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.AspNet.OutputCache.sln))\tools\TestProject.settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tools/MicrosoftAspNetOutputCache.settings.targets
+++ b/tools/MicrosoftAspNetOutputCache.settings.targets
@@ -32,6 +32,7 @@
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <OutputPath>$(RepositoryRoot)bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(RepositoryRoot)obj\$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/TestProject.settings.props
+++ b/tools/TestProject.settings.props
@@ -1,0 +1,7 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This pull request introduces a shared MSBuild property file for test projects and ensures consistent configuration of the `CompilerGeneratedFilesOutputPath` property across both main and test builds. It also makes a minor adjustment to the Azure pipeline configuration.

**Build and test configuration standardization:**

* Added a new shared MSBuild property file `tools/TestProject.settings.props` to define `CompilerGeneratedFilesOutputPath` for test projects, promoting consistency and reducing duplication.
* Updated test project files (`.csproj`) to import the new shared property file, ensuring all test projects use the same configuration for generated files. [[1]](diffhunk://#diff-853a06d801f1821555a187093d456628a449e2df0bcd1d7665458f9aea9d3ef8R4) [[2]](diffhunk://#diff-322c248541483aa36cca605065fd1cea86da7c255681ba5d1e96cedf3d8bcbb5R7) [[3]](diffhunk://#diff-ceb38428c60e25b464af285cc33a3a82e8cce49cab340be231ac478b76100cb9R7)
* Set `CompilerGeneratedFilesOutputPath` in `tools/MicrosoftAspNetOutputCache.settings.targets` for main builds, aligning with the test project configuration.

**Pipeline configuration:**

* Removed the redundant `sbomBuildDropPath` property from the Azure pipeline YAML, likely to prevent conflicts or unnecessary duplication.